### PR TITLE
Make grobid-client-python pip installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,5 @@ setup(name='grobid-client-python',
       description='grobid-client-python',
       author=' kermitt2',
       packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+      license='LICENSE',
     )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+setup(name='grobid-client-python',
+      version='0.0.1',
+      description='grobid-client-python',
+      author=' kermitt2',
+      packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(name='grobid-client-python',
       version='0.0.1',
       description='grobid-client-python',
-      author=' kermitt2',
+      author='kermitt2',
       packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
       license='LICENSE',
     )


### PR DESCRIPTION
By adding a setup.py, grobid-client-python can be installed using pip directly from github.

Eg, `pip install git+https://github.com/nlothian/grobid-client-python.git`
