### PR TITLE
Created a download argument for running the client

### DIFF
--- a/test-cache.py
+++ b/test-cache.py
@@ -1,0 +1,27 @@
+'''
+Recursively apply GROBID to the PDF present in a file tree via the grobid client and save the output XMLs in a cache without downloading them locally.
+'''
+
+import os
+import re
+import json
+import time
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import subprocess
+import xml.etree.ElementTree as ET
+
+grobid = __import__('grobid-client')
+
+if __name__ == '__main__':
+    
+    client = grobid.grobid_client(config_path="./config.json")
+    input_path = "/mnt/data/covid/data/"
+    for root, _, _ in os.walk(input_path):
+        client.process(root, root, 10, "processFulltextDocument", False, 1, 0, True, True, True, False, False)
+        print(root)
+        
+    # client.cache contains a list of tuples containing the file name, path, and the XML output in a string form
+    print(client.cache)
+

--- a/test.py
+++ b/test.py
@@ -1,5 +1,5 @@
 '''
-Recursively apply GROBID to the PDF present in a file tree via the grobid client.
+Recursively apply GROBID to the PDF present in a file tree via the grobid client and download the output XMLs locally.
 '''
 
 import os
@@ -10,6 +10,6 @@ if __name__ == "__main__":
     client = grobid.grobid_client(config_path="./config.json")
     input_path = "/mnt/data/covid/data/"
     for root, _, _ in os.walk(input_path):
-        client.process(root, root, 10, "processFulltextDocument", False, 1, 0, True, True, True, False)
+        client.process(root, root, 10, "processFulltextDocument", False, 1, 0, True, True, True, False, True)
         print(root)
                 


### PR DESCRIPTION
Hello!

Myself and my colleagues at NASA Jet Propulsion Laboratory got to use the Grobid Python Client for an internal project and have found it extremely useful for parsing scientific papers and extracting useful information from them. Grobid is certainly one of the most incredible parsing tools out there and it has helped us tremendously, so thank you so much for all your work!

Something that we really wanted to use the client for was the ability to parse the PDFs without downloading the output XMLs locally. I didn't see it as an option/argument for the client so I created it and added it to the code. In short, passing the `--download` flag as `False` will save the output in a cache represented by a list of tuples, where each tuple represents a file and it contains the filename, the path, and the XML output in a string form. Later on, the cache (`client.cache`) can be used for further parsing if need be (see an example in `test-cache.py`). Passing the `--download` flag as `True` will save the XML files locally, as the client did before my modifications. 

I wanted to share my modifications in case they could be of use to others. Please let me know if you have any questions or concerns!

Anastasija